### PR TITLE
Update for more recent ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "http://rubygems.org" 
 gemspec
 
-gem 'simplecov'
+gem 'simplecov', :require => false, :group => :test
+gem 'test-unit', :require => false, :group => :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,25 +7,29 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    docile (1.1.5)
     gemma (2.4.0)
       highline (~> 1.6.15)
       minitest (~> 2.12.1)
       rake (~> 0.9.2)
       rdoc (~> 3.12.0)
       yard (~> 0.8.2)
-    highline (1.6.15)
-    json (1.7.5)
+    highline (1.6.21)
+    json (1.8.6)
     minitest (2.12.1)
-    multi_json (1.3.6)
+    power_assert (0.4.1)
     pqueue (2.0.2)
-    rake (0.9.2.2)
-    rdoc (3.12)
+    rake (0.9.6)
+    rdoc (3.12.2)
       json (~> 1.4)
-    simplecov (0.7.1)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.7.1)
-    simplecov-html (0.7.1)
-    yard (0.8.3)
+    simplecov (0.14.1)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.1)
+    test-unit (3.2.3)
+      power_assert
+    yard (0.8.7.6)
 
 PLATFORMS
   ruby
@@ -35,3 +39,7 @@ DEPENDENCIES
   discrete_event!
   gemma (~> 2.4.0)
   simplecov
+  test-unit
+
+BUNDLED WITH
+   1.15.1


### PR DESCRIPTION
Effectively `bundle update simplecov`.